### PR TITLE
BUG: Prevent zero division in np.angle replacement

### DIFF
--- a/tike/ptycho.py
+++ b/tike/ptycho.py
@@ -365,7 +365,8 @@ def grad(
         # Go far-plane
         farplane = np.fft.fft2(nearplane_pad)
         # Replace the amplitude with the measured amplitude.
-        farplane = (np.sqrt(data) * (farplane.real + 1j * farplane.imag)
+        farplane[farplane == 0] = 1  # no division by zero allowed
+        farplane = (np.sqrt(data) * farplane
                     / np.sqrt(farplane.imag * farplane.imag
                               + farplane.real * farplane.real))
         # Back to near-plane.


### PR DESCRIPTION
We previously replaced numpy angle with a cheaper alternative
but because of zero division it did not behave the same as
np.angle. This patch makes the trig identity behave the same way
as numpy angle when the complex number is zero. nan and inf were
not considered in this patch.